### PR TITLE
Allow for no context file to be specified

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,9 +15,8 @@ module.exports = transformTools.makeStringTransform('preprocessify', {},
         } else if (config.contextFile) {
             context = JSON.parse(fs.readFileSync(config.contextFile, 'utf8'));
         } else {
-            done(new Error('A context object or file must be specified (e.g. "browserify -t [preprocessify --contextFile ./path/to/file.json] app.js" or "b.transform(preprocessify, {context: {FOO:BAR}})"'));
+            context = {};
         }
 
         done(null, pp.preprocess(content, context, {type: 'js'}));
     });
-


### PR DESCRIPTION
Hi,

sometimes you just want to use the `@exclude` keyword, and don't need to specify a context file. i.e.

"The most basic usage is for files that only have two states, non-processed and processed. In this case, your `@exclude` directives are removed after preprocessing"

take from https://github.com/jsoverson/preprocess

with thanks
